### PR TITLE
feat(travel): Multiple travel events per journey

### DIFF
--- a/src/merchant_tycoon/domain/model/city.py
+++ b/src/merchant_tycoon/domain/model/city.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict
+
+
+@dataclass
+class TravelEventsConfig:
+    """Configuration for travel events in a city.
+
+    Attributes:
+        loss_min: Minimum number of loss events (default: 0)
+        loss_max: Maximum number of loss events (default: 2)
+        gain_min: Minimum number of gain events (default: 0)
+        gain_max: Maximum number of gain events (default: 2)
+    """
+    loss_min: int = 0
+    loss_max: int = 2
+    gain_min: int = 0
+    gain_max: int = 2
 
 
 @dataclass
@@ -26,6 +42,8 @@ class City:
             Example: {"TV": 1.0, "Ferrari": 1.25, "Cocaine": 0.5}
             means TV is normal price, Ferrari is 25% more expensive, and
             Cocaine is 50% cheaper in this city.
+        travel_events: Configuration for travel events when arriving in this city.
+            Controls how many loss and gain events can occur per journey.
 
     Examples:
         >>> warsaw = City("Warsaw", "Poland", {"TV": 1.0, "Ferrari": 1.0})
@@ -41,3 +59,4 @@ class City:
     name: str
     country: str
     price_multiplier: Dict[str, float]  # Per-good multipliers for this city
+    travel_events: TravelEventsConfig = field(default_factory=TravelEventsConfig)

--- a/src/merchant_tycoon/template/style.tcss
+++ b/src/merchant_tycoon/template/style.tcss
@@ -418,8 +418,8 @@ ConfirmModal, AboutModal, CargoExtendModal, NewGameModal {
     background: #2f3543;
 }
 
-/* Alert modal styles */
-AlertModal {
+/* Alert and Event modal styles */
+AlertModal, EventModal {
     align: center middle;
     background: transparent;   /* keep app visible under alerts */
 }

--- a/src/merchant_tycoon/ui/general/modals/__init__.py
+++ b/src/merchant_tycoon/ui/general/modals/__init__.py
@@ -7,6 +7,7 @@ from merchant_tycoon.ui.general.modals.cargo_extend_modal import CargoExtendModa
 from merchant_tycoon.ui.general.modals.about_modal import AboutModal
 from merchant_tycoon.ui.general.modals.splash_modal import SplashModal
 from merchant_tycoon.ui.general.modals.new_game_modal import NewGameModal
+from merchant_tycoon.ui.general.modals.event_modal import EventModal
 
 __all__ = [
     "HelpModal",
@@ -18,4 +19,5 @@ __all__ = [
     "AboutModal",
     "SplashModal",
     "NewGameModal",
+    "EventModal",
 ]

--- a/src/merchant_tycoon/ui/general/modals/event_modal.py
+++ b/src/merchant_tycoon/ui/general/modals/event_modal.py
@@ -1,0 +1,46 @@
+from textual.app import ComposeResult
+from textual.containers import Container
+from textual.widgets import Label, Button
+from textual.screen import ModalScreen
+
+
+class EventModal(ModalScreen):
+    """Modal for displaying travel events with callback support"""
+
+    BINDINGS = [
+        ("escape", "dismiss_modal", "Close"),
+        ("enter", "dismiss_modal", "Close"),
+    ]
+
+    def __init__(self, title: str, message: str, is_positive: bool, callback):
+        super().__init__()
+        self.alert_title = title
+        self.alert_message = message
+        self.is_positive = is_positive
+        self.callback = callback
+
+    def compose(self) -> ComposeResult:
+        modal_id = "alert-modal-positive" if self.is_positive else "alert-modal-negative"
+        with Container(id=modal_id):
+            # Uppercase the title while preserving leading emoji + single space
+            t = self.alert_title or ""
+            parts = t.split(None, 1)
+            if len(parts) == 2:
+                t = f"{parts[0]} {parts[1].upper()}"
+            else:
+                t = t.upper()
+            yield Label(t, id="modal-title")
+            yield Label(self.alert_message, id="alert-message")
+            yield Button("OK (ENTER)", variant=("success" if self.is_positive else "error"), id="ok-btn")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ok-btn":
+            self.dismiss()
+            if self.callback:
+                self.callback()
+
+    def action_dismiss_modal(self) -> None:
+        """Close the modal when ESC or ENTER is pressed"""
+        self.dismiss()
+        if self.callback:
+            self.callback()


### PR DESCRIPTION
Original prompt:


Goal:
Enhance the travel experience by allowing multiple sequential travel events to occur during a single journey.
This extends the current single-event logic without breaking compatibility with the existing 25% base probability and weighted event selection system.

Description:
- Maintain the current event generation process and 25% base probability check.
- If an event trigger occurs (based on base probability), generate multiple events instead of one.
- The number of events per trip depends on the city configuration.
- Each event is selected independently using the existing weighted selection logic.
- Events are displayed to the player sequentially via modal dialogs that require confirmation before proceeding.
- make sure that events will not duplicate during single travel

Technical Requirements:

1. Preserve existing probability logic:
   - Keep `SETTINGS.events.base_probability` (e.g. 0.25).
   - Continue using the same initial check:
     ```python
     if random.random() >= SETTINGS.events.base_probability:
         return []
     ```
   - Only if the probability check passes, proceed to multi-event generation.

2. Extend city configuration:
   - Add nested configuration under each city:
     ```python
     "travel_events": {
         "loss": {"min": int, "max": int},
         "gain": {"min": int, "max": int}
     }
     ```
   - Example:
     "Warsaw": {
         "travel_events": {
             "loss": {"min": 0, "max": 2},
             "gain": {"min": 0, "max": 2}
         }
     }

3. Generate multiple events:
   - After passing the probability check:
     ```python
     loss_cfg = city["travel_events"]["loss"]
     gain_cfg = city["travel_events"]["gain"]

     loss_count = random.randint(loss_cfg["min"], loss_cfg["max"])
     gain_count = random.randint(gain_cfg["min"], gain_cfg["max"])
     ```
   - For each count, call the existing event selection logic:
     ```python
     loss_events = [select_weighted_event("loss") for _ in range(loss_count)]
     gain_events = [select_weighted_event("gain") for _ in range(gain_count)]
     ```
   - Combine all selected events into a single list and shuffle:
     ```python
     all_events = loss_events + gain_events
     random.shuffle(all_events)
     return all_events
     ```

4. Sequential modal handling:
   - Modify travel event presentation layer:
     - For each event in the list:
       - Display modal with event details.
       - Wait for user confirmation (OK) before proceeding.
     - After the final event, close modal sequence and return control to player.
   - Ensure all events execute sequentially and cleanly.

5. Integration:
   - Keep the existing event weighting and eligibility system intact.
   - Multi-event mode should only modify how many times the selection runs, not the logic itself.
   - If `travel_events` config is missing → fallback to a single event as before.

6. Validation:
   - Verify system works correctly with different city configurations.
   - Confirm event count stays within defined min/max limits.
   - Ensure multiple events do not conflict (e.g. trying to remove already-lost inventory).
   - Test sequential modals for proper order, blocking, and confirmation flow.

Deliverables:
- Updated travel event generation system supporting multiple events.
- Extended city configuration with nested `travel_events.loss/gain` min/max fields.
- Sequential modal display logic.
- Backward-compatible integration with current probability and weighted selection system.
